### PR TITLE
Uncomment the WALL-E Job Trigger.

### DIFF
--- a/pegr/grails-app/jobs/pegr/WalleJob.groovy
+++ b/pegr/grails-app/jobs/pegr/WalleJob.groovy
@@ -2,11 +2,11 @@ package pegr
 
 class WalleJob {
     static triggers = {
-      //simple name: 'sendSequenceRunToWalle', startDelay: 1000 * 60 * 5, repeatInterval: 1000 * 60 * 15, repeatCount: -1 // execute job once every 15 min
+      simple name: 'sendSequenceRunToWalle', startDelay: 1000 * 60 * 5, repeatInterval: 1000 * 60 * 15, repeatCount: -1 // execute job once every 15 min
     }
 
     def concurrent = false
-    
+
     def walleService
 
     def execute() {


### PR DESCRIPTION
WalleJob.groovy file had the WALL-E job trigger commented. Which is now uncommented.