### PR TITLE
Sort sequence runs based on Run ID

### DIFF
--- a/pegr/grails-app/controllers/pegr/SequenceRunController.groovy
+++ b/pegr/grails-app/controllers/pegr/SequenceRunController.groovy
@@ -23,7 +23,7 @@ class SequenceRunController {
         def c = SequenceRun.createCriteria()
         def listParams = [
                 max: params.max ?: 25,
-                sort: params.sort ?: "date",
+                sort: params.sort ?: "id",
                 order: params.order ?: "desc",
                 offset: params.offset
             ]

--- a/pegr/grails-app/views/sequenceRun/_table.gsp
+++ b/pegr/grails-app/views/sequenceRun/_table.gsp
@@ -2,7 +2,7 @@
     <table class="table table-bordered">
         <thead>
             <tr>
-                <g:sortableColumn property="runNum" defaultOrder="desc" title="Run #"></g:sortableColumn>
+                <g:sortableColumn property="id" defaultOrder="desc" title="Run #"></g:sortableColumn>
                 <g:sortableColumn property="date" defaultOrder="desc" title="Date"></g:sortableColumn>
                 <th>Sample Details</th>
                 <g:sortableColumn property="status" title="Status and QC"></g:sortableColumn>


### PR DESCRIPTION
Changed date to id to sort based on the first column. However, if you would like to sort based on the RunNum, the order will be based on the old RunNum.

This commits resolves: https://github.com/seqcode/pegr/issues/23