### PR TITLE
Fix pagination in sequencing reports

### DIFF
--- a/pegr/grails-app/controllers/pegr/SequenceRunController.groovy
+++ b/pegr/grails-app/controllers/pegr/SequenceRunController.groovy
@@ -22,10 +22,10 @@ class SequenceRunController {
     def index(Integer max, String str, String status){
         def c = SequenceRun.createCriteria()
         def listParams = [
-                max: params.max ?: 25,
-                sort: params.sort ?: "id",
+                max: params.max ?: 50,
+                sort: params.sort ?: "id", //if you would like to sort based on the runNum, just remeber it's basically for the old run number.
                 order: params.order ?: "desc",
-                offset: params.offset
+                offset: params.offset ?: 0
             ]
         def runs
 	def galaxy = Holders.config.defaultGalaxy

--- a/pegr/grails-app/views/sequenceRun/index.gsp
+++ b/pegr/grails-app/views/sequenceRun/index.gsp
@@ -57,7 +57,7 @@
         </div>
     </div>
     <div class="pagination">
-        <g:paginate next="Next" prev="Prev" params="${params}" total="${runs.totalCount ?: 0}" />
+        <g:paginate next="Next" prev="Prev" max="${params.max ?: 50}" offset="${params.offset ?: 0}" total="${runs.totalCount ?: 0}" />
     </div>
     <script>
         $(".nav-runs").addClass("active");


### PR DESCRIPTION
The number of rows/records displayed in sequencing report pages is not fixed for all pages.
Changed the default params to set max # of records in each page to 50 with 0 offset.
This commit fixes: https://github.com/seqcode/pegr/issues/22