### PR TITLE
Fix User Column on Protocols Tab

### DIFF
--- a/pegr/grails-app/views/protocol/_overviewProtocols.gsp
+++ b/pegr/grails-app/views/protocol/_overviewProtocols.gsp
@@ -1,8 +1,8 @@
 <div class="table-responsive">
     <table class="table">
         <thead>
-            <tr>					
-                <g:sortableColumn property="name" title="Name" />					
+            <tr>
+                <g:sortableColumn property="name" title="Name" />
                 <g:sortableColumn property="protocolVersion" title="Version" />
                 <g:sortableColumn property="description" title="Description" />
                 <g:sortableColumn property="user" title="User" />
@@ -11,11 +11,12 @@
         </thead>
         <tbody>
         <g:each in="${protocolList}" status="i" var="protocol">
-            <tr class="${(i % 2) == 0 ? 'even' : 'odd'}">					
-                <td><g:link action="show" id="${protocol.id}">${fieldValue(bean: protocol, field: "name")}</g:link></td>					
+            <tr class="${(i % 2) == 0 ? 'even' : 'odd'}">
+                <td><g:link action="show" id="${protocol.id}">${fieldValue(bean: protocol, field: "name")}</g:link></td>
                 <td>${fieldValue(bean: protocol, field: "protocolVersion")}</td>
                 <td>${fieldValue(bean: protocol, field: "description")}</td>
-                <td>${protocol.user}</td>
+                <!-- pjchaffin | Pierce Chaffin | Fixed user column to make it just xxxXXXX not User(username:xxxXXXX) ... as it was an object -->
+                <td>${protocol.user.username}</td>
                 <td>${protocol.status}</td>
             </tr>
         </g:each>


### PR DESCRIPTION
Changes User column data from User(username:xxxXXXX) to xxxXXXX (aka the psu email)
Problem here was page was displaying an object rather than value simple change from protocol.user to protocol.user.username
Files Changed: pegr/grails-app/views/protocol/_overviewProtocols.gsp
Fixes: #35