### PR TITLE
Removes Deduplicated Column from Report/runStatus

### DIFF
--- a/pegr/grails-app/views/report/_generalQc.gsp
+++ b/pegr/grails-app/views/report/_generalQc.gsp
@@ -33,6 +33,7 @@
                 </g:if>
                 <th class="text-right col-tags group-qc">Requested Tags</th>
                 <g:each in="${qcSettings.general}" var="setting">
+                  <g:if test="${setting.name != "Deduplicated"}">
                     <th class="text-right col-${setting.key} group-qc">
                         ${setting.name}
                         <ul style="font-weight: normal">
@@ -42,6 +43,7 @@
                             <g:if test="${setting.reference_max}"><li>min: ${setting.reference_max}</li></g:if>
                         </ul>
                     </th>
+                  </g:if>
                 </g:each>
                 <th class="col-prefer group-operation"><label class="switch"><input id="verifyAll" class="prefer2" type="checkbox"><div class="slider round"></div></label><span class="isAdmin" style="display:none">${isAdmin}</span>
 					</br>Verified</th>


### PR DESCRIPTION
Adds conditional logic to the gsp page such that it excludes the Deduplicated data
Files Changed: pegr/grails-app/views/report/_generalQc.gsp
Resolves: #51